### PR TITLE
 Fix combined styles (short object notation)

### DIFF
--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -226,7 +226,7 @@ export default class DateTimePicker extends Component {
     } = this.props;
 
     return (
-      <div style={{ ...styles.container, style }} className={this.props.className}>
+      <div style={{ ...styles.container, ...style }} className={this.props.className}>
         <TextField
           onFocus={this.handleFocus}
           className={textFieldClassName}


### PR DESCRIPTION
Due to short object notation, combined style resulted in 
`{
        display: 'flex',
        alignItems: 'flex-end',
style : {
        gridRow: 1,
        gridColumn: 1
      }
      }`
  instead of  
`{
        display: 'flex',
        alignItems: 'flex-end',
        gridRow: 1,
        gridColumn: 1
      }`